### PR TITLE
Simple gateway support. Example localrc entries

### DIFF
--- a/contrail_config_templates.py
+++ b/contrail_config_templates.py
@@ -257,6 +257,33 @@ agent_conf_template = string.Template("""
 </config>
 """)
 
+agent_vgw_conf_template = string.Template("""
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+ <agent>
+  <!-- Physical ports connecting to IP Fabric -->
+  <vhost>
+   <name>vhost0</name>
+   <ip-address>$__contrail_box_ip__</ip-address>
+   <gateway>$__contrail_gateway__</gateway>
+  </vhost>
+  <eth-port>
+   <name>$__contrail_intf__</name>
+  </eth-port>
+  <control>
+   <ip-address>$__contrail_control_ip__</ip-address>
+  </control>
+  <xmpp-server>
+   <ip-address>$__contrail_control_ip__</ip-address>
+  </xmpp-server>
+  <gateway virtual-network="$__contrail_vgw_public_network__">
+    <interface>$__contrail_vgw_interface__</interface>
+    <subnet>$__contrail_vgw_public_subnet__</subnet>
+  </gateway>
+ </agent>
+</config>
+""")
+
 ifconfig_vhost0_template = string.Template("""
 #Contrail vhost0
 DEVICE=vhost0

--- a/stack.sh
+++ b/stack.sh
@@ -1568,7 +1568,6 @@ if [ $ENABLE_CONTRAIL ]; then
     if [ $CONTRAIL_VGW_INTERFACE -a $CONTRAIL_VGW_PUBLIC_SUBNET -a $CONTRAIL_VGW_PUBLIC_NETWORK ]; then
         sudo sysctl -w net.ipv4.ip_forward=1
         sudo /opt/stack/contrail/build/debug/vrouter/utils/vif --create vgw --mac 00:01:00:5e:00:00
-        #sudo tunctl -p -t vgw
         sudo ifconfig vgw up
         sudo route add -net $CONTRAIL_VGW_PUBLIC_SUBNET dev vgw
     fi

--- a/unstack.sh
+++ b/unstack.sh
@@ -152,5 +152,11 @@ if [ $? == 0 ]; then
         sudo rm -f /etc/sysconfig/network-scripts/ifcfg-vhost0
     fi
 fi
+if [ $CONTRAIL_VGW_PUBLIC_SUBNET ]; then
+    sudo route del -net $CONTRAIL_VGW_PUBLIC_SUBNET dev vgw
+fi
+if [ $CONTRAIL_VGW_INTERFACE ]; then
+    sudo tunctl -d vgw
+fi
 
 cleanup_tmp


### PR DESCRIPTION
Simple gateway support. Example localrc entries,
CONTRAIL_VGW_INTERFACE=vgw
CONTRAIL_VGW_PUBLIC_SUBNET=2.2.2.0/24
CONTRAIL_VGW_PUBLIC_NETWORK=default-domain:admin:public:public
