### PR TITLE
devstack+contrail works on ubuntu

### DIFF
--- a/contrail_config_templates.py
+++ b/contrail_config_templates.py
@@ -2,6 +2,7 @@ import string
 
 api_server_conf_template = string.Template("""
 [DEFAULTS]
+reset_config=True
 ifmap_server_ip=$__contrail_ifmap_server_ip__
 ifmap_server_port=$__contrail_ifmap_server_port__
 ifmap_username=$__contrail_ifmap_username__
@@ -229,7 +230,7 @@ kmod=vrouter/vrouter.ko
 pname=vnswad
 LIBDIR=/usr/lib64
 VHOST_CFG=/etc/sysconfig/network-scripts/ifcfg-vhost0
-VROUTER_LOGFILE=--log-file=/var/log/contrail/vrouter.log
+VROUTER_LOGFILE=--log-file=/var/log/vrouter.log
 COLLECTOR=$__contrail_collector__
 $__contrail_dev__
 """)


### PR DESCRIPTION
devstack+contrail works on ubuntu, single host.  The API server starts.  I can create networks, boot VMs, and ssh into them.

updated latest version of repo url
install distribute before other python libs
added reset_config=True to api_server.conf
don't start cassandra at boot, just by stack.sh
handle python package install paths with pywhere
make a fake contrail-version when contrail isn't installed by yum
