### PR TITLE
Fix redis conf file path

### DIFF
--- a/lib/neutron_thirdparty/contrail
+++ b/lib/neutron_thirdparty/contrail
@@ -273,7 +273,7 @@ function start_contrail() {
     screen -r $SCREEN_NAME -X hardstatus alwayslastline "$SCREEN_HARDSTATUS"
 
     # launch ...
-    screen_it redis "sudo redis-server /etc/redis.conf"
+    screen_it redis "sudo redis-server /etc/redis/redis.conf"
     screen_it cass "sudo /usr/sbin/cassandra -f"
     screen_it zk  "cd $CONTRAIL_SRC/third_party/zookeeper-3.4.5; ./bin/zkServer.sh start"
     screen_it ifmap "cd $CONTRAIL_SRC/third_party/irond-0.3.0-bin; java -jar ./irond.jar"

--- a/lib/neutron_thirdparty/contrail
+++ b/lib/neutron_thirdparty/contrail
@@ -273,7 +273,11 @@ function start_contrail() {
     screen -r $SCREEN_NAME -X hardstatus alwayslastline "$SCREEN_HARDSTATUS"
 
     # launch ...
+    if is_ubuntu; then
+    screen_it redis "sudo redis-server /etc/redis/redis.conf"
+    else
     screen_it redis "sudo redis-server /etc/redis.conf"
+    fi
     screen_it cass "sudo /usr/sbin/cassandra -f"
     screen_it zk  "cd $CONTRAIL_SRC/third_party/zookeeper-3.4.5; ./bin/zkServer.sh start"
     screen_it ifmap "cd $CONTRAIL_SRC/third_party/irond-0.3.0-bin; java -jar ./irond.jar"
@@ -379,4 +383,5 @@ function stop_contrail() {
 }
 
 # Restore xtrace
+
 $MY_XTRACE


### PR DESCRIPTION
On Ubuntu 12.04 the redis configuration file path is '/etc/redis/redis.conf' and not '/etc/redis.conf'
