### PR TITLE
call provision_linklocal.py to enable metadata server

### DIFF
--- a/contrail/localrc-multinode-compute
+++ b/contrail/localrc-multinode-compute
@@ -1,7 +1,7 @@
-HOST_IP=192.168.56.103 # publicly routable ip to me
+#HOST_IP=192.168.56.104 # publicly routable ip to me
 
 # change this to your master node's ip
-SERVICE_HOST=172.18.4.119 # control1
+SERVICE_HOST=192.168.56.119 # control1
 
 # the interface that contrail's vhost0 should take over
 PHYSICAL_INTERFACE=eth0

--- a/lib/neutron_thirdparty/contrail
+++ b/lib/neutron_thirdparty/contrail
@@ -365,6 +365,19 @@ END
 
     screen_it vif  "python /opt/stack/nova/plugins/contrail/contrail_vif.py"
 
+    if is_service_enabled q-meta; then
+	# set up a proxy route in contrail from 169.254.169.254:80 to
+	# my metadata server at port 8775
+	python /opt/stack/contrail/controller/src/config/utils/provision_linklocal.py \
+	    --linklocal_service_name metadata \
+	    --linklocal_service_ip 169.254.169.254 \
+	    --linklocal_service_port 80 \
+	    --ipfabric_service_ip $Q_META_DATA_IP \
+	    --ipfabric_service_port 8775 \
+	    --oper add
+    fi
+
+
     # restore saved screen settings
     SCREEN_NAME=$SAVED_SCREEN_NAME
 }


### PR DESCRIPTION
Thought I'd put this into stack.sh insead of always calling tit by hand.  Now the metadata server will work out of the box.
