### PR TITLE
Fix error when load environments from command-line.

### DIFF
--- a/contrail/localrc-multinode-compute
+++ b/contrail/localrc-multinode-compute
@@ -9,7 +9,7 @@ PHYSICAL_INTERFACE=eth0
 ENABLE_CONTRAIL=yes
 Q_PLUGIN=contrail
 
-STACK_DIR=$(cd $(dirname $0) && pwd)
+STACK_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}) && pwd)
 
 # log all screen output to this directory
 SCREEN_LOGDIR=$STACK_DIR/log/screens

--- a/contrail/localrc-multinode-server
+++ b/contrail/localrc-multinode-server
@@ -12,7 +12,7 @@ PHYSICAL_INTERFACE=eth0
 MULTI_HOST=True
 Q_PLUGIN=contrail
 
-STACK_DIR=$(cd $(dirname $0) && pwd)
+STACK_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}) && pwd)
 
 # log all screen output to this directory
 SCREEN_LOGDIR=$STACK_DIR/log/screens

--- a/contrail/localrc-single
+++ b/contrail/localrc-single
@@ -1,4 +1,4 @@
-STACK_DIR=$(cd $(dirname $0) && pwd)
+STACK_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}) && pwd)
 
 SCREEN_LOGDIR=$STACK_DIR/log/screens
 LOG=True


### PR DESCRIPTION
e.g.
  $ source openrc
  dirname: invalid option -- 'b'
  Try 'dirname --help' for more information.
