### PR TITLE
Ubuntu does not support anymore package chkconfig

### DIFF
--- a/lib/neutron_thirdparty/contrail
+++ b/lib/neutron_thirdparty/contrail
@@ -24,7 +24,8 @@ function install_contrail() {
 
     # dependencies
     if is_ubuntu; then
-	apt_get install patch scons flex bison make vim chkconfig
+	apt_get install patch scons flex bison make vim
+    apt_get install chkconfig
 	apt_get install libexpat-dev libgettextpo0 libcurl4-openssl-dev
 	apt_get install python-dev autoconf automake build-essential libtool
 	apt_get install libevent-dev libxml2-dev libxslt-dev


### PR DESCRIPTION
From release 12.10, Ubuntu removed the support of chkconfig package.
I set a specific install chkconfig command in case it fails, it fails
alone.
