### PR TITLE
Add Quota support

### DIFF
--- a/lib/neutron_plugins/contrail
+++ b/lib/neutron_plugins/contrail
@@ -22,7 +22,7 @@ function neutron_plugin_configure_common() {
 }
 
 function neutron_plugin_configure_service() {
-    iniset $NEUTRON_CONF quotas quota_driver neutron.quota.ConfDriver
+    iniset $NEUTRON_CONF quotas quota_driver neutron.plugins.juniper.contrail.quota.driver.QuotaDriver
 }
 
 function neutron_plugin_configure_debug_command() {


### PR DESCRIPTION
Set the default quota driver to : neutron.plugins.juniper.contrail.contrailplugin.QuotaConfDriver

Signed-off-by: Nicolas PLANEL nicolas.planel@enovance.com
